### PR TITLE
improve the typehint of model.find, to catch a typo where a param is …

### DIFF
--- a/firedantic/_async/model.py
+++ b/firedantic/_async/model.py
@@ -97,7 +97,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find(
-        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+        cls: Type[TAsyncBareModel], filter_: Optional[dict[str, str | dict]] = None
     ) -> List[TAsyncBareModel]:
         """Returns a list of models from the database based on a filter.
 
@@ -155,7 +155,7 @@ class AsyncBareModel(pydantic.BaseModel, ABC):
 
     @classmethod
     async def find_one(
-        cls: Type[TAsyncBareModel], filter_: Optional[dict] = None
+        cls: Type[TAsyncBareModel], filter_: Optional[dict[str, str | dict]] = None
     ) -> TAsyncBareModel:
         """Returns one model from the DB based on a filter.
 

--- a/firedantic/_sync/model.py
+++ b/firedantic/_sync/model.py
@@ -96,7 +96,7 @@ class BareModel(pydantic.BaseModel, ABC):
         return getattr(self, self.__document_id__, None)
 
     @classmethod
-    def find(cls: Type[TBareModel], filter_: Optional[dict] = None) -> List[TBareModel]:
+    def find(cls: Type[TBareModel], filter_: Optional[dict[str, str | dict]] = None) -> List[TBareModel]:
         """Returns a list of models from the database based on a filter.
 
         Example: `Company.find({"company_id": "1234567-8"})`.
@@ -152,7 +152,7 @@ class BareModel(pydantic.BaseModel, ABC):
             return query
 
     @classmethod
-    def find_one(cls: Type[TBareModel], filter_: Optional[dict] = None) -> TBareModel:
+    def find_one(cls: Type[TBareModel], filter_: Optional[dict[str, str | dict]] = None) -> TBareModel:
         """Returns one model from the DB based on a filter.
 
         :param filter_: The filter criteria.


### PR DESCRIPTION
…a set instead of dict:

'id': {"==": my_id},
'some_value': {">=", condition_value} #has , instead of :